### PR TITLE
Fix JSON string escaping

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "start": "npm run build && node scripts/start.js",
         "start:debug": "npm run build && node scripts/start-debug.js"
     },
-    "description": "Сайт кузницы "Д.Гена" на основе шаблона Bootstrap.",
+    "description": "Сайт кузницы \"Д.Гена\" на основе шаблона Bootstrap.",
     "keywords": [
         "css",
         "sass",


### PR DESCRIPTION
## Summary
- fix quoting for `description` in `package.json`

## Testing
- `npm test` *(fails: missing script)*
- `bun install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685bcfaad6608322bc752ac01beec9cb