### PR TITLE
Darken header background

### DIFF
--- a/dist/css/styles.css
+++ b/dist/css/styles.css
@@ -10947,7 +10947,7 @@ header.masthead {
   padding-bottom: 6rem;
   text-align: center;
   color: #fff;
-  background: linear-gradient(135deg, #000000 0%, #d35400 100%);
+  background: linear-gradient(135deg, #000000 0%, #943a00 100%);
 }
 header.masthead .masthead-subheading {
   font-size: 1.5rem;

--- a/src/scss/sections/_masthead.scss
+++ b/src/scss/sections/_masthead.scss
@@ -7,7 +7,7 @@ header.masthead {
     padding-bottom: 6rem;
     text-align: center;
     color: $white;
-    background-image: url("../assets/img/header-bg.jpg");
+    background: linear-gradient(135deg, #000000 0%, #943a00 100%);
     background-repeat: no-repeat;
     background-attachment: scroll;
     background-position: center center;


### PR DESCRIPTION
## Summary
- darken the masthead background gradient in source SCSS
- sync compiled CSS with darker color

## Testing
- `npm run build` *(fails: Cannot find module 'shelljs')*

------
https://chatgpt.com/codex/tasks/task_e_685bd62641bc83228d6edd3321de6e27