### PR TITLE
Fix server initialization

### DIFF
--- a/server.js
+++ b/server.js
@@ -8,6 +8,18 @@ app.use(express.urlencoded({ extended: true }));
 
 const DATA_DIR = path.join(__dirname, 'data');
 
+// Ensure data directory and JSON files exist so that the server
+// does not fail when writing to them on first run.
+if (!fs.existsSync(DATA_DIR)) {
+  fs.mkdirSync(DATA_DIR, { recursive: true });
+}
+['services', 'portfolio', 'about', 'team'].forEach(name => {
+  const p = path.join(DATA_DIR, `${name}.json`);
+  if (!fs.existsSync(p)) {
+    fs.writeFileSync(p, '[]');
+  }
+});
+
 function readData(name) {
   const p = path.join(DATA_DIR, `${name}.json`);
   if (!fs.existsSync(p)) return [];


### PR DESCRIPTION
## Summary
- ensure `data` directory and files exist on server startup

## Testing
- `npm run build` *(fails: cannot find module 'shelljs')*

------
https://chatgpt.com/codex/tasks/task_e_685bdfa6e3248322a3f9f9a81abd728c