### PR TITLE
Fix Netlify publish

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  command = "npm run build"
+  publish = "dist"


### PR DESCRIPTION
## Summary
- add `netlify.toml` so Netlify uses the correct build command and publish directory

## Testing
- `npm run build` *(fails: Cannot find module 'shelljs')*

------
https://chatgpt.com/codex/tasks/task_e_685be7999d78832293af2d2e0365e734