### PR TITLE
Move CTA text outside timeline circle

### DIFF
--- a/src/pug/index.pug
+++ b/src/pug/index.pug
@@ -204,12 +204,14 @@ html(lang='ru')
                                     | Внедрили инновационные методы ковки и обработки металла.
                     li.timeline-inverted
                         .timeline-image
-                            h4
-                                | Будьте частью
-                                br
-                                | нашей
-                                br
-                                | истории!
+                        .timeline-panel
+                            .timeline-heading
+                                h4
+                                    | Будьте частью
+                                    br
+                                    | нашей
+                                    br
+                                    | истории!
 
         // Team
         section#team.page-section.bg-light


### PR DESCRIPTION
## Summary
- move final call-to-action text next to the timeline circle instead of inside it

## Testing
- `npm run build` *(fails: Cannot find module 'shelljs')*

------
https://chatgpt.com/codex/tasks/task_e_685beb4537cc832283b751bf5978c0ea